### PR TITLE
Polyfill for String.prototype.includes

### DIFF
--- a/plugins/draw-projects.user.js
+++ b/plugins/draw-projects.user.js
@@ -29,6 +29,13 @@ window.plugin.drawProjects = function() {};
 window.plugin.drawProjects.PREKEY = 'plugin-draw-tools-layer';
 window.plugin.drawProjects.projects = [];
 
+if (!String.prototype.includes) {
+    String.prototype.includes = function () {
+        'use strict';
+        return String.prototype.indexOf.apply(this, arguments) !== -1;
+    };
+}
+
 window.plugin.drawProjects.scanStorage = function() {
   // Create drawtools default localstorage if it not exist
   if(!window.localStorage[window.plugin.drawProjects.PREKEY]) {


### PR DESCRIPTION
There were troubles in FF 38.0.1, so I added polyfill from MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes

